### PR TITLE
add optional JDBC driver class name configuration parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change log
 ======
 
+## 1.0.21 (2018-11-29)
+
+ * Adding optional JDBC driver class name on config
+
 ## 1.0.20 (2016-11-29)
 
  * Adding leakDetectionThreshold config

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ It doesn't implement the mysql protocol or manage jdbc connections by itself. It
                             .build();
   
 ```
+
+**NOTE**: In some systems if the driver classname is not set, a NoActiveNodeException is thrown. To avoid it use the driverClassName() method on Builder
+
 There are few more options for configuration, you can check these in the [source code].
 
 #### 2) Getting a Connection

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>com.despegar</groupId>
 	<artifactId>galera-java-client</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.20</version>
+	<version>1.0.21</version>
 
 	<name>galera-java-client</name>
 	<url>https://github.com/despegar/galera-java-client</url>

--- a/src/main/java/com/despegar/jdbc/galera/GaleraClient.java
+++ b/src/main/java/com/despegar/jdbc/galera/GaleraClient.java
@@ -392,6 +392,7 @@ public class GaleraClient extends AbstractGaleraDataSource {
         private String password = "";
         private Optional<String> jdbcUrlPrefix = Optional.absent();
         private Optional<String> jdbcUrlSeparator = Optional.absent();
+        private Optional<String> driverClassName = Optional.absent();
         private String seeds;
         private int maxConnectionsPerHost;
         private int minConnectionsIdlePerHost = 1;
@@ -438,7 +439,8 @@ public class GaleraClient extends AbstractGaleraDataSource {
 
             GaleraDB galeraDB = new GaleraDB(database, user, password,
                     jdbcUrlPrefix.or(GaleraDB.MYSQL_URL_PREFIX),
-                    jdbcUrlSeparator.or(GaleraDB.MYSQL_URL_SEPARATOR));
+                    jdbcUrlSeparator.or(GaleraDB.MYSQL_URL_SEPARATOR),
+                    driverClassName);
 
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Creating galera client with connection settings: {}", galeraDB);
@@ -503,6 +505,11 @@ public class GaleraClient extends AbstractGaleraDataSource {
 
         public Builder jdbcUrlSeparator(String jdbcUrlSeparator) {
             this.jdbcUrlSeparator = Optional.fromNullable(jdbcUrlSeparator);
+            return this;
+        }
+
+        public Builder driverClassName(String driverClassName) {
+            this.driverClassName = Optional.fromNullable(driverClassName);
             return this;
         }
 

--- a/src/main/java/com/despegar/jdbc/galera/GaleraClientFactory.java
+++ b/src/main/java/com/despegar/jdbc/galera/GaleraClientFactory.java
@@ -13,6 +13,7 @@ public class GaleraClientFactory {
     private String jdbcUrlPrefix;
     private String jdbcUrlSeparator;
     private String seeds;
+    private String driverClassName;
     private int maxConnectionsPerHost;
     private int minConnectionsIdlePerHost;
     private long discoverPeriod;
@@ -39,7 +40,7 @@ public class GaleraClientFactory {
                 .connectionTimeout(connectionTimeout).connectTimeout(connectTimeout).readTimeout(readTimeout).idleTimeout(idleTimeout).ignoreDonor(ignoreDonor)
                 .retriesToGetConnection(retriesToGetConnection).autocommit(autocommit).readOnly(readOnly).isolationLevel(isolationLevel)
                 .consistencyLevel(consistencyLevel).listener(listener).nodeSelectionPolicy(nodeSelectionPolicy).testMode(testMode).metricsEnabled(
-                        metricsEnabled).leakDetectionThreshold(leakDetectionThreshold).build();
+                        metricsEnabled).leakDetectionThreshold(leakDetectionThreshold).driverClassName(driverClassName).build();
     }
 
     public void setDatabase(String database) {
@@ -140,6 +141,10 @@ public class GaleraClientFactory {
 
     public void setLeakDetectionThreshold(long leakDetectionThreshold) {
         this.leakDetectionThreshold = leakDetectionThreshold;
+    }
+
+    public void setDriverClassName(String driverClassName) {
+        this.driverClassName = driverClassName;
     }
 
 }

--- a/src/main/java/com/despegar/jdbc/galera/GaleraDB.java
+++ b/src/main/java/com/despegar/jdbc/galera/GaleraDB.java
@@ -1,8 +1,10 @@
 package com.despegar.jdbc.galera;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class GaleraDB {
     public static final String MYSQL_URL_PREFIX = "jdbc:mysql://";
@@ -13,17 +15,19 @@ public class GaleraDB {
     public final String database;
     public final String user;
     public final String password;
+    public final Optional<String> driverClassName;
 
     public GaleraDB(@Nonnull String database, @Nonnull String user, @Nonnull String password) {
-        this(database, user, password, MYSQL_URL_PREFIX, MYSQL_URL_SEPARATOR);
+        this(database, user, password, MYSQL_URL_PREFIX, MYSQL_URL_SEPARATOR, Optional.<String>absent());
     }
 
-    public GaleraDB(@Nonnull String database, @Nonnull String user, @Nonnull String password, @Nonnull String jdbcUrlPrefix, @Nonnull String jdbcUrlSeparator) {
+    public GaleraDB(@Nonnull String database, @Nonnull String user, @Nonnull String password, @Nonnull String jdbcUrlPrefix, @Nonnull String jdbcUrlSeparator, Optional<String> driverClassName) {
         this.database = database;
         this.user = user;
         this.password = password;
         this.jdbcUrlPrefix = jdbcUrlPrefix;
         this.jdbcUrlSeparator = jdbcUrlSeparator;
+        this.driverClassName = driverClassName;
     }
 
     @Override
@@ -34,6 +38,7 @@ public class GaleraDB {
                 .add("jdbcUrlSeparator", jdbcUrlSeparator)
                 .add("database", database)
                 .add("user", user)
+                .add("driverClassName", driverClassName.orNull())
                 .toString();
     }
 }

--- a/src/main/java/com/despegar/jdbc/galera/GaleraNode.java
+++ b/src/main/java/com/despegar/jdbc/galera/GaleraNode.java
@@ -74,6 +74,10 @@ public class GaleraNode {
             config.setMetricRegistry(GaleraClient.metricRegistry);
         }
 
+        if(galeraDB.driverClassName.isPresent()){
+            config.setDriverClassName(galeraDB.driverClassName.get());
+        }
+
         return config;
     }
 


### PR DESCRIPTION
In some systems (aka my pc), the DB connection initialization throws an NoActiveNodeException even if all DB nodes are up and active.
The cause of this is that the Java DriverManager do not find a registered driver for the JVM.
Again, this happened to me only, but with this optional (and non interfering) config parameter it was fixed.